### PR TITLE
Add automatic tag page generation

### DIFF
--- a/.github/workflows/generate-tags.yml
+++ b/.github/workflows/generate-tags.yml
@@ -1,0 +1,78 @@
+name: Auto-Generate Tag Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '_posts/**'
+      - '.github/workflows/generate-tags.yml'
+
+jobs:
+  generate-tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract and generate tag pages
+        run: |
+          echo "🔍 Scanning posts for tags..."
+
+          # Extract all unique tags from posts
+          tags=$(grep -rh "^tags:" _posts/ | sed 's/tags: //' | tr ' ' '\n' | sort -u | grep -v "^$")
+
+          tag_count=0
+          new_tags=0
+
+          # Create tag directory if it doesn't exist
+          mkdir -p tag
+
+          # Create tag page for each tag
+          for tag in $tags; do
+            tag_count=$((tag_count + 1))
+            tagfile="tag/${tag}.md"
+
+            # Skip if already exists
+            if [ -f "$tagfile" ]; then
+              echo "  ✓ $tag (already exists)"
+              continue
+            fi
+
+            # Create new tag page
+            cat > "$tagfile" << EOF
+          ---
+          layout: tagpage
+          title: "Tag: $tag"
+          tag: $tag
+          robots: noindex
+          ---
+          EOF
+
+            echo "  ✨ $tag (created)"
+            new_tags=$((new_tags + 1))
+          done
+
+          echo ""
+          echo "📊 Summary:"
+          echo "  Total tags: $tag_count"
+          echo "  New tags created: $new_tags"
+
+      - name: Commit and push new tag pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add tag/
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "✅ No new tag pages to commit"
+          else
+            git commit -m "Auto-generate tag pages [skip ci]"
+            git push
+            echo "✅ New tag pages committed and pushed"
+          fi

--- a/scripts/generate-tags.sh
+++ b/scripts/generate-tags.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+##
+# Manual Tag Page Generator
+# Run this if you want to manually generate tag pages
+# Usage: ./scripts/generate-tags.sh
+##
+
+set -e
+
+echo "🔍 Scanning posts for tags..."
+
+# Extract all unique tags from posts
+tags=$(grep -rh "^tags:" _posts/ | sed 's/tags: //' | tr ' ' '\n' | sort -u | grep -v "^$")
+
+tag_count=0
+new_tags=0
+
+# Create tag directory if it doesn't exist
+mkdir -p tag
+
+# Create tag page for each tag
+for tag in $tags; do
+  tag_count=$((tag_count + 1))
+  tagfile="tag/${tag}.md"
+
+  # Skip if already exists
+  if [ -f "$tagfile" ]; then
+    echo "  ✓ $tag (already exists)"
+    continue
+  fi
+
+  # Create new tag page
+  cat > "$tagfile" << EOF
+---
+layout: tagpage
+title: "Tag: $tag"
+tag: $tag
+robots: noindex
+---
+EOF
+
+  echo "  ✨ $tag (created)"
+  new_tags=$((new_tags + 1))
+done
+
+echo ""
+echo "📊 Summary:"
+echo "  Total tags: $tag_count"
+echo "  New tags created: $new_tags"
+
+if [ $new_tags -gt 0 ]; then
+  echo ""
+  echo "✅ New tag pages created!"
+  echo "📝 Don't forget to commit them:"
+  echo "   git add tag/"
+  echo "   git commit -m 'Add new tag pages'"
+  echo "   git push"
+else
+  echo ""
+  echo "✅ All tag pages are up to date!"
+fi


### PR DESCRIPTION
Created GitHub Action workflow + manual script to auto-generate tag pages.

Features:
✅ Auto-generates tag pages when posts are added/modified ✅ Runs on every push to main that affects _posts/
✅ Creates missing tag pages automatically
✅ Prevents 404s for new tags
✅ No manual tag page creation needed

Files:
- .github/workflows/generate-tags.yml - Auto-runs on push
- scripts/generate-tags.sh - Manual script (backup)

How it works:
1. Scans all posts for tags
2. Checks which tag pages exist
3. Creates missing tag pages
4. Auto-commits with [skip ci] to prevent loops

Now you can:
- Add any tag to a post
- Push to main
- Tag page auto-generates
- No 404s ever! 🎉